### PR TITLE
Allowing ImageDimensions to implicitly be converted to ValueTuple<lon…

### DIFF
--- a/src/OpenSlideNET/OpenSlideImage.cs
+++ b/src/OpenSlideNET/OpenSlideImage.cs
@@ -425,6 +425,15 @@ namespace OpenSlideNET
                 height = _height;
             }
 
+            public static implicit operator (long Width, long Height)(ImageDimemsions dimemsions)
+            {
+                return (Width: dimemsions._width, Height: dimemsions._height);
+            }
+
+            public static explicit operator ImageDimemsions(ValueTuple<long, long> dimemsions)
+            {
+                return new ImageDimemsions(dimemsions.Item1, dimemsions.Item2);
+            }
         }
 
         #region IDisposable Support

--- a/tests/OpenSlideNET.Tests/Basics.cs
+++ b/tests/OpenSlideNET.Tests/Basics.cs
@@ -87,23 +87,11 @@ namespace OpenSlideNET.Tests
             using (var osr = OpenSlideImage.Open(Path.Combine(currentDir, "Assets", "boxes.tiff")))
             {
                 Assert.Equal(4, osr.LevelCount);
-                long width, height;
 
-                osr.GetLevelDimemsions(0).Deconstruct(out width, out height);
-                Assert.Equal(300, width);
-                Assert.Equal(250, height);
-
-                osr.GetLevelDimemsions(1).Deconstruct(out width, out height);
-                Assert.Equal(150, width);
-                Assert.Equal(125, height);
-
-                osr.GetLevelDimemsions(2).Deconstruct(out width, out height);
-                Assert.Equal(75, width);
-                Assert.Equal(62, height);
-
-                osr.GetLevelDimemsions(3).Deconstruct(out width, out height);
-                Assert.Equal(37, width);
-                Assert.Equal(31, height);
+                Assert.Equal<ValueTuple<long, long>>((300, 250), osr.GetLevelDimemsions(0));
+                Assert.Equal<ValueTuple<long, long>>((150, 125), osr.GetLevelDimemsions(1));
+                Assert.Equal<ValueTuple<long, long>>((75, 62), osr.GetLevelDimemsions(2));
+                Assert.Equal<ValueTuple<long, long>>((37, 31), osr.GetLevelDimemsions(3));
 
                 Assert.Equal(1, osr.GetLevelDownsamples(0));
                 Assert.Equal(2, osr.GetLevelDownsamples(1));


### PR DESCRIPTION
…g, long>